### PR TITLE
feat: add video hero section with brand colors

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,20 +5,33 @@ import { Button } from "@/components/ui/button";
 
 const Index: React.FC = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">Welcome to MyAccurate Books</h1>
-        <p className="text-xl text-gray-600 mb-8">Your complete accounting solution for business financial management</p>
-        <div className="flex gap-4 justify-center">
-          <Button asChild>
-            <Link to="/features">Explore Features</Link>
-          </Button>
-          <Button variant="outline" asChild>
-            <Link to="/demo">Watch Demo</Link>
-          </Button>
+    <section className="relative h-screen w-full overflow-hidden">
+      <video
+        className="absolute inset-0 h-full w-full object-cover"
+        src="https://cdn.coverr.co/videos/coverr-birds-flying-in-slow-motion-1536/mp4/mp4?download=true"
+        autoPlay
+        loop
+        muted
+      />
+      <div className="absolute inset-0 bg-[#1f5fc0]/70 flex items-center justify-center">
+        <div className="text-center text-[#ffb354]">
+          <h1 className="text-4xl font-bold mb-4 animate-bounce">Welcome to MyAccurate Books</h1>
+          <p className="text-xl mb-8 animate-pulse">Your complete accounting solution for business financial management</p>
+          <div className="flex gap-4 justify-center">
+            <Button asChild className="bg-[#ffb354] text-[#1f5fc0] hover:bg-[#ffb354]/90">
+              <Link to="/features">Explore Features</Link>
+            </Button>
+            <Button
+              variant="outline"
+              asChild
+              className="text-[#ffb354] border-[#ffb354] hover:bg-[#ffb354]/10"
+            >
+              <Link to="/demo">Watch Demo</Link>
+            </Button>
+          </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- add full-screen bird video hero for landing page
- overlay animated text using brand colors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 18 problems)


------
https://chatgpt.com/codex/tasks/task_e_68909fda18048322aad1bd61d97aae30